### PR TITLE
Issue#1 Removed Commented Out Lines in MjpegFileWriter.java

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -148,17 +148,6 @@ public class MjpegFileWriter {
         raf.close();
     }
 
-    // public void writeAVI(File file) throws Exception
-    // {
-    // OutputStream os = new FileOutputStream(file);
-    //
-    // // RIFFHeader
-    // // AVIMainHeader
-    // // AVIStreamList
-    // // AVIStreamHeader
-    // // AVIStreamFormat
-    // // write 00db and image bytes...
-    // }
     public static int swapInt(int v) {
         return (v >>> 24) | (v << 24) | ((v << 8) & 0x00FF0000) | ((v >> 8) & 0x0000FF00);
     }


### PR DESCRIPTION
**Describe the technical debt**
Commented-out code distracts the focus from the actual executed code, especially if it does not add any value. It creates noise that increases maintenance code.

**Variable name**
Not Applicable

**Location**
File: MjpegFileWriter.java
Path: jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java

**Reason for Change**
Reduce maintenance code and noise.

**To Reproduce**
Not Applicable

**Expected behavior**
After removing this variable, the project should still compile and build with no errors, and the behavior of the application should remain exactly the same.

**Screenshot**
![Screenshot (107)](https://github.com/user-attachments/assets/bff27b7c-21e3-43f2-91a1-e80e0fa26fca)
