### PR TITLE
Fixes #116 - Checkstyle library version update

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -206,7 +206,7 @@ tasks.withType(Sign) {
 }
 
 checkstyle {
-    toolVersion '9.3'
+    toolVersion '10.20.1'
     configFile file("${gradle.rootProject.rootDir}/config/checkstyle/checkstyle.xml")
 }
 


### PR DESCRIPTION
Fixes #116
Checkstyle library version updated from 9.3 to 10.20.1
This will fix 2 security vulnerabilities found in the Guava 31.0.1 library which was referenced by the Checkstyle 9.3 library.