### PR TITLE
fix: Make sure the use of WRITE_EXTERNAL_STORAGE permission is necess…

### DIFF
--- a/jme3-android-examples/src/main/AndroidManifest.xml
+++ b/jme3-android-examples/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:normalScreens="true"
             android:smallScreens="true"/>
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.VIBRATE"/>


### PR DESCRIPTION
Describe the Software Vulnerability
The identified vulnerabilities involve the improper or unnecessary use of dangerous Android permissions, such as:

WRITE_EXTERNAL_STORAGE: Grants the app permission to write data to external storage. This poses risks of unauthorized access to sensitive user data if exploited.
READ_PHONE_STATE: Allows the app to access telephony-related information, such as phone state and network details, which can lead to privacy breaches if misused.
READ_EXTERNAL_STORAGE: Grants the app permission to read data from external storage. Like the WRITE permission, this can lead to data exposure if improperly managed.
Data Backup Safety: Ensures application data backups are secure and do not expose sensitive data.
The key concern here is whether these permissions are essential for the app's functionality. Unnecessary permissions increase the attack surface, leading to potential exploitation by malicious entities.

Type of Vulnerability
Security Hotspot related to Android permissions.

CVE
[CWE-250 - Execution with Unnecessary Privileges](https://cwe.mitre.org/data/definitions/250)

Expected outcome
The app will now use permissions that are less sensitive, reducing the risk of security vulnerabilities.
Compliance with secure coding practices will be achieved, enhancing the app's overall security posture.
The app will still retain necessary functionality without compromising user privacy unnecessarily.

Code before refactoring

![image](https://github.com/user-attachments/assets/7efb4e0e-f1ba-4192-b7da-de9d54e02593)


Code after refactoring
![image](https://github.com/user-attachments/assets/35e2600a-bcc6-4621-860c-c391579bfae4)

Issue
https://github.com/rilling/jmonkeyengineFall2024/issues/168